### PR TITLE
Tests for creation of remote relationships

### DIFF
--- a/server/tests-py/gql_prefixer_proxy.py
+++ b/server/tests-py/gql_prefixer_proxy.py
@@ -1,0 +1,291 @@
+from http import HTTPStatus
+import requests
+import json
+import re
+import graphql
+
+from webserver import RequestHandler, WebServer, MkHandlers, Response
+
+def first(iterable, key, default=None):
+   return next( (x for x in iterable if key(x)), default)
+
+def get_introspect_types(introspect):
+   return json_get(introspect, ['data', '__schema', 'types'])
+
+def has_name(name):
+   return lambda x : x['name'] == name
+
+def get_fld_by_name(flds, name):
+   return first(flds, has_name(name))
+
+def get_ty_by_name(types, name):
+   return first(types, has_name(name))
+
+def json_get(obj, path, default=None):
+   if obj == None:
+      return None
+   elif len(path) == 0:
+      return obj
+   elif len(path) == 1:
+      return obj.get(path[0], default)
+   else:
+      return json_get(obj.get(path[0],{ }), path[1:])
+
+def get_base_ty(fld):
+   base_ty = fld['type']
+   while not base_ty['name']:
+      base_ty = base_ty['ofType']
+   return base_ty
+
+class GraphQLPrefixerProxy(RequestHandler):
+   """
+   This proxy adds a prefix to all the object type names (except for the default ones), 
+    and also to the top level fields of queries, mutations and subscriptions.
+
+   Further to enable adding this as remote schema to the server it is proxying,
+   It also deletes all the types starting with the prefix, and the top-level nodes starting with same prefix.
+   """
+
+   def __init__(self, gql_url, headers, prefix):
+      self.gql_url = gql_url
+      self.headers = headers
+      self.prefix = prefix
+
+   def _is_non_def_obj_ty(self, ty):
+      return ty['kind'] in ['OBJECT'] and not ty['name'].startswith('__')
+
+   def _is_input_obj_ty(self, ty):
+      return ty['kind'] in ['INPUT_OBJECT']
+
+   def _is_enum(self, ty):
+      return ty['kind'] == 'ENUM'
+
+   def _add_name_prefix(self, obj):
+      assert not obj['name'].startswith(self.prefix), obj
+      obj['name'] = self.prefix + obj['name']
+
+   def get(self, request):
+      return Response(HTTPStatus.METHOD_NOT_ALLOWED)
+
+   def _assert_prefixes(self, introspect):
+
+      def assert_fld_name(fld):
+         return assert_ty_name(fld)
+
+      def assert_ty_name(ty):
+         assert ty['name'].startswith(self.prefix), ty
+         assert_no_loop(ty)
+
+      def assert_no_loop(ty):
+         assert not ty['name'].startswith(self.prefix*2), ty
+
+      def assert_base_ty(elem):
+         base_ty = get_base_ty(elem)
+         assert_no_loop(base_ty), elem
+         return base_ty
+
+      types = get_introspect_types(introspect)
+      if not types:
+         return
+
+      for ty in types:
+         assert_no_loop(ty)
+         if self._is_non_def_obj_ty(ty):
+            # Ensure name of type starts with prefix
+            assert_ty_name(ty)
+
+            # Ensure base type of fields starts with prefix,
+            # if base type is object
+            for fld in ty['fields']:
+               base_ty = assert_base_ty(fld)
+               if self._is_non_def_obj_ty(base_ty) or self._is_enum(base_ty):
+                  assert_ty_name(base_ty)
+
+               # Ensure base type of args starts with prefix,
+               # if base type is input_object
+               for arg in fld['args']:
+                  base_ty = assert_base_ty(arg)
+                  if self._is_input_obj_ty(base_ty) or self._is_enum(base_ty):
+                     assert_ty_name(base_ty)
+
+         elif self._is_input_obj_ty(ty):
+            # Ensure name of input object starts with prefix
+            assert_ty_name(ty)
+
+            for fld in ty['inputFields']:
+               base_ty = assert_base_ty(fld)
+               if self._is_input_obj_ty(base_ty) or self._is_enum(base_ty):
+                  assert_ty_name(base_ty)
+
+         elif self._is_enum(ty):
+            assert_ty_name(ty)
+
+      for oper_type in ['queryType', 'mutationType', 'subscriptionType']:
+         ty = json_get(introspect, ['data', '__schema', oper_type])
+         if not ty:
+            continue
+         assert_ty_name(ty)
+         ty = get_ty_by_name(types, ty['name'])
+
+         for fld in ty['fields']:
+            assert_fld_name(fld)
+
+   def _mod_types_introspect(self, introspect):
+
+      def remove_if_base_ty_has_prefix(elems):
+         to_remove_elems = []
+         for elem in elems:
+            base_ty = get_base_ty(elem)
+            if base_ty['name'].startswith(self.prefix):
+               to_remove_elems.append(elem)
+         for elem in to_remove_elems:
+            elems.remove(elem)
+
+      def mod_fld_args(fld):
+         remove_if_base_ty_has_prefix(fld['args'])
+         for arg in fld['args']:
+            base_ty = get_base_ty(arg)
+            if self._is_input_obj_ty(base_ty) or self._is_enum(base_ty):
+               self._add_name_prefix(base_ty)
+
+      def mod_obj_fields(ty):
+         remove_if_base_ty_has_prefix(ty['fields'])
+         for fld in ty['fields']:
+            base_ty = get_base_ty(fld)
+            if self._is_non_def_obj_ty(base_ty) or self._is_enum(base_ty):
+               self._add_name_prefix(base_ty)
+            mod_fld_args(fld)
+
+      def mod_inp_obj_fields(ty):
+         remove_if_base_ty_has_prefix(ty['inputFields'])
+         for fld in ty['inputFields']:
+            base_ty = get_base_ty(fld)
+            if self._is_input_obj_ty(base_ty) or self._is_enum(base_ty):
+               self._add_name_prefix(base_ty)
+
+      def mod_obj(ty):
+         self._add_name_prefix(ty)
+         mod_obj_fields(ty)
+
+      def mod_inp_obj(ty):
+         self._add_name_prefix(ty)
+         mod_inp_obj_fields(ty)
+
+      types = get_introspect_types(introspect)
+      if not types:
+         return
+
+      to_remove_types=[]
+      for ty in types:
+         # If types from server start with the given prefix, remove them
+         # This would avoid cycles being created when this proxy
+         # is added as remote to the GraphQL server itself
+         if ty['name'].startswith(self.prefix):
+            to_remove_types.append(ty)
+         elif self._is_non_def_obj_ty(ty):
+            mod_obj(ty)
+         elif self._is_input_obj_ty(ty):
+            mod_inp_obj(ty)
+         elif self._is_enum(ty):
+            self._add_name_prefix(ty)
+
+      for ty in to_remove_types:
+         types.remove(ty)
+
+      # Add prefix to the operation types
+      for oper_type in ['queryType', 'mutationType', 'subscriptionType']:
+         ty_info = json_get(introspect, ['data', '__schema', oper_type])
+         if ty_info and not ty_info['name'].startswith(self.prefix):
+            self._add_name_prefix(ty_info)
+
+   # With queries we need to strip prefix from top level fields (if present)
+   def _query_mod_top_level_fields(self, req):
+
+      def set_alias_if_absent(fld):
+         if not fld.alias:
+            fld.alias = graphql.NameNode(value=fld.name.value)
+
+      def remove_prefix(fld):
+         fld.name.value = re.sub(
+            '^'+ re.escape(self.prefix), '',
+            top_fld.name.value )
+
+      errors = []
+      query = graphql.parse(req['query'], no_location=True)
+      for oper in query.definitions:
+         if not getattr(oper, 'operation', None):
+            continue
+         for top_fld in oper.selection_set.selections:
+            if top_fld.name.value.startswith(self.prefix):
+               set_alias_if_absent(top_fld)
+               remove_prefix(top_fld)
+            elif top_fld.name.value not in ['__schema', '__type', '__typename' ]:
+               errors.append('Unknown field ' + top_fld.name.value)
+      req['query'] = graphql.print_ast(query)
+      return errors
+
+
+   # Add prefix for top level fields of all the operation types
+   def _mod_top_level_fields_introspect(self, introspect):
+      types = get_introspect_types(introspect)
+      if not types:
+         return
+
+      def remove_fields_with_prefix(ty):
+         to_drop_fields = []
+         for fld in ty['fields']:
+            if fld['name'].startswith(self.prefix):
+               to_drop_fields.append(fld)
+         for fld in to_drop_fields:
+            ty['fields'].remove(fld)
+
+      for oper_type in ['queryType', 'mutationType', 'subscriptionType']:
+         ty_name = json_get(introspect, ['data', '__schema', oper_type, 'name'])
+         if not ty_name:
+            continue
+         ty = get_ty_by_name(types, ty_name)
+
+         remove_fields_with_prefix(ty)
+         for fld in ty['fields']:
+            self._add_name_prefix(fld)
+
+   def post(self, request):
+      input_query = request.json.copy()
+
+      def log_if_input_query_changed():
+         if request.json.get('query') != input_query.get('query'):
+            print("Prefixer proxy: GrahpQL url:", self.gql_url)
+            print ("input query:", input_query)
+            print ("proxied query:", request.json)
+
+      def modify_introspect_output(json_out):
+         self._mod_top_level_fields_introspect(json_out)
+         self._mod_types_introspect(json_out)
+         self._assert_prefixes(json_out)
+
+      if not request.json:
+         return Response(HTTPStatus.BAD_REQUEST)
+
+      errors = self._query_mod_top_level_fields(request.json)
+      if errors:
+         print('ERROR:',errors)
+         json_out = {'errors': errors}
+      else:
+         log_if_input_query_changed()
+         resp = requests.post(self.gql_url, json.dumps(request.json), headers=self.headers)
+         json_out = resp.json()
+         if json_out.get('errors'):
+            print('ERROR:', json_out['errors'])
+         modify_introspect_output(json_out)
+      return Response(HTTPStatus.OK, json_out, {'Content-Type': 'application/json'})
+
+handlers = MkHandlers({ '/graphql': GraphQLPrefixerProxy })
+
+def MkGQLPrefixerProxy(gql_url, headers={}, prefix='prefixer_proxy_'):
+   class _GQLPrefixerProxy(GraphQLPrefixerProxy):
+      def __init__(self):
+         super().__init__(gql_url, headers, prefix)
+   return _GQLPrefixerProxy
+
+def create_server(gql_url, headers={}, host='127.0.0.1', port=5000):
+   return WebServer((host, port), MkGQLPrefixerProxy(gql_url, headers) )

--- a/server/tests-py/queries/graphql_query/permissions/jsonb_has_all.yaml
+++ b/server/tests-py/queries/graphql_query/permissions/jsonb_has_all.yaml
@@ -26,8 +26,8 @@
   status: 200
   headers:
     X-Hasura-Role: user5
-    X-Hasura-Protected-Jsons: |-
-      {}
+    X-Hasura-Json-Required-Keys: |-
+      {location}
   response:
     data:
       jsonb_table: []

--- a/server/tests-py/queries/remote_schemas/add_remote_schema_err_missing_arg.yaml
+++ b/server/tests-py/queries/remote_schemas/add_remote_schema_err_missing_arg.yaml
@@ -11,6 +11,6 @@ query:
   args:
     name: err-missing-arg
     definition:
-      url: http://localhost:5000/iface-graphql-err-missing-arg
+      url: ${REMOTE_GRAPHQL_ROOT_URL}/iface-graphql-err-missing-arg
       headers: []
       forward_client_headers: true

--- a/server/tests-py/queries/remote_schemas/add_remote_schema_err_missing_field.yaml
+++ b/server/tests-py/queries/remote_schemas/add_remote_schema_err_missing_field.yaml
@@ -11,6 +11,6 @@ query:
   args:
     name: err-missing-arg
     definition:
-      url: http://localhost:5000/iface-graphql-err-missing-field
+      url: ${REMOTE_GRAPHQL_ROOT_URL}/iface-graphql-err-missing-field
       headers: []
       forward_client_headers: true

--- a/server/tests-py/queries/remote_schemas/add_remote_schema_err_unknown_interface.yaml
+++ b/server/tests-py/queries/remote_schemas/add_remote_schema_err_unknown_interface.yaml
@@ -11,6 +11,6 @@ query:
   args:
     name: err-unknown-iface
     definition:
-      url: http://localhost:5000/iface-graphql-err-unknown-iface
+      url: ${REMOTE_GRAPHQL_ROOT_URL}/iface-graphql-err-unknown-iface
       headers: []
       forward_client_headers: true

--- a/server/tests-py/queries/remote_schemas/add_remote_schema_iface_err_wrong_arg_type.yaml
+++ b/server/tests-py/queries/remote_schemas/add_remote_schema_iface_err_wrong_arg_type.yaml
@@ -11,6 +11,6 @@ query:
   args:
     name: err-missing-arg
     definition:
-      url: http://localhost:5000/iface-graphql-err-wrong-arg-type
+      url: ${REMOTE_GRAPHQL_ROOT_URL}/iface-graphql-err-wrong-arg-type
       headers: []
       forward_client_headers: true

--- a/server/tests-py/queries/remote_schemas/add_remote_schema_with_iface_err_empty_fields_list.yaml
+++ b/server/tests-py/queries/remote_schemas/add_remote_schema_with_iface_err_empty_fields_list.yaml
@@ -11,6 +11,6 @@ query:
   args:
     name: err-unknown-types
     definition:
-      url: http://localhost:5000/iface-graphql-err-empty-field-list
+      url: ${REMOTE_GRAPHQL_ROOT_URL}/iface-graphql-err-empty-field-list
       headers: []
       forward_client_headers: true

--- a/server/tests-py/queries/remote_schemas/add_remote_schema_with_iface_err_extra_non_null_arg.yaml
+++ b/server/tests-py/queries/remote_schemas/add_remote_schema_with_iface_err_extra_non_null_arg.yaml
@@ -11,6 +11,6 @@ query:
   args:
     name: err-unknown-types
     definition:
-      url: http://localhost:5000/iface-graphql-err-extra-non-null-arg
+      url: ${REMOTE_GRAPHQL_ROOT_URL}/iface-graphql-err-extra-non-null-arg
       headers: []
       forward_client_headers: true

--- a/server/tests-py/queries/remote_schemas/add_remote_schema_with_iface_err_wrong_field_type.yaml
+++ b/server/tests-py/queries/remote_schemas/add_remote_schema_with_iface_err_wrong_field_type.yaml
@@ -11,6 +11,6 @@ query:
   args:
     name: err-unknown-types
     definition:
-      url: http://localhost:5000/iface-graphql-err-wrong-field-type
+      url: ${REMOTE_GRAPHQL_ROOT_URL}/iface-graphql-err-wrong-field-type
       headers: []
       forward_client_headers: true

--- a/server/tests-py/queries/remote_schemas/add_remote_schema_with_union_err_member_type_interface.yaml
+++ b/server/tests-py/queries/remote_schemas/add_remote_schema_with_union_err_member_type_interface.yaml
@@ -11,6 +11,6 @@ query:
   args:
     name: err-unknown-types
     definition:
-      url: http://localhost:5000/union-graphql-err-subtype-iface
+      url: ${REMOTE_GRAPHQL_ROOT_URL}/union-graphql-err-subtype-iface
       headers: []
       forward_client_headers: true

--- a/server/tests-py/queries/remote_schemas/add_remote_schema_with_union_err_no_member_types.yaml
+++ b/server/tests-py/queries/remote_schemas/add_remote_schema_with_union_err_no_member_types.yaml
@@ -11,6 +11,6 @@ query:
   args:
     name: err-no-mem-types
     definition:
-      url: http://localhost:5000/union-graphql-err-no-member-types
+      url: ${REMOTE_GRAPHQL_ROOT_URL}/union-graphql-err-no-member-types
       headers: []
       forward_client_headers: true

--- a/server/tests-py/queries/remote_schemas/add_remote_schema_with_union_err_unknown_types.yaml
+++ b/server/tests-py/queries/remote_schemas/add_remote_schema_with_union_err_unknown_types.yaml
@@ -11,6 +11,6 @@ query:
   args:
     name: err-unknown-types
     definition:
-      url: http://localhost:5000/union-graphql-err-unknown-types
+      url: ${REMOTE_GRAPHQL_ROOT_URL}/union-graphql-err-unknown-types
       headers: []
       forward_client_headers: true

--- a/server/tests-py/queries/remote_schemas/add_remote_schema_with_union_err_wrapped_type.yaml
+++ b/server/tests-py/queries/remote_schemas/add_remote_schema_with_union_err_wrapped_type.yaml
@@ -11,6 +11,6 @@ query:
   args:
     name: err-unknown-types
     definition:
-      url: http://localhost:5000/union-graphql-err-wrapped-type
+      url: ${REMOTE_GRAPHQL_ROOT_URL}/union-graphql-err-wrapped-type
       headers: []
       forward_client_headers: true

--- a/server/tests-py/queries/remote_schemas/basic_bulk_remove_add.yaml
+++ b/server/tests-py/queries/remote_schemas/basic_bulk_remove_add.yaml
@@ -9,5 +9,5 @@ args:
     name: simple 2
     comment: testing
     definition:
-      url: http://localhost:5000/hello-graphql
+      url: ${REMOTE_GRAPHQL_ROOT_URL}/hello-graphql
       forward_client_headers: false

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup.yaml
@@ -1,0 +1,174 @@
+type: bulk
+args:
+
+- type: run_sql
+  args:
+    sql: |
+      create table users (
+          id serial primary key,
+          provider text not null
+      );
+
+      create table profiles (
+          id integer primary key references users(id),
+          name text not null,
+          alias text not null unique,
+          internal jsonb
+      );
+
+      create table messages (
+          id serial primary key,
+          profile_id integer not null references profiles(id),
+          message text
+      );
+
+      create table authors (
+          id serial primary key,
+          alias text unique not null references profiles(alias),
+          user_id integer not null references users(id),
+          biography text
+      );
+
+      create table articles (
+          id serial primary key,
+          author_id integer not null references authors(id),
+          title text not null,
+          info jsonb
+          );
+- type: track_table
+  args:
+    schema: public
+    name: users
+- type: track_table
+  args:
+    schema: public
+    name: profiles
+- type: track_table
+  args:
+    schema: public
+    name: messages
+- type: track_table
+  args:
+    schema: public
+    name: authors
+- type: track_table
+  args:
+    schema: public
+    name: articles
+#Object relationship
+- type: create_object_relationship
+  args:
+    table: articles
+    name: author
+    using:
+      foreign_key_constraint_on: author_id
+- type: create_object_relationship
+  args:
+    table: authors
+    name: user
+    using:
+      foreign_key_constraint_on: user_id
+- type: create_object_relationship
+  args:
+    table: messages
+    name: profile
+    using:
+      foreign_key_constraint_on: profile_id
+- type: create_object_relationship
+  args:
+    table: profiles
+    name: user
+    using:
+      foreign_key_constraint_on: id
+- type: create_object_relationship
+  args:
+    name: profile
+    table:
+      name: users
+      schema: public
+    using:
+      manual_configuration:
+        remote_table:
+          name: profiles
+          schema: public
+        column_mapping:
+          id: id
+#Array relationships
+- type: create_array_relationship
+  args:
+    table: profiles
+    name: messages
+    using:
+      foreign_key_constraint_on:
+        table: messages
+        column: profile_id
+#Array relationships
+- type: create_array_relationship
+  args:
+    table: authors
+    name: articles
+    using:
+      foreign_key_constraint_on:
+        table: articles
+        column: author_id
+- type: run_sql
+  args:
+    sql: |
+      insert into users (id, provider) values
+      (1,'provider1' ),
+      (2,'provider2'),
+      (3,'provider1');
+
+      insert into profiles (id, name, alias) values
+      (1, 'Jane', 'jane-the-great' ),
+      (2, 'John', 'john-the-stunner'),
+      (3, 'Joe', 'awesome-joe' );
+
+      insert into messages (profile_id, message) values
+      (1, '(from table) You win' ),
+      (2, '(from table) You lose');
+
+      insert into authors (alias, user_id, biography) values
+      ('jane-the-great', 1, 'Bio of Jane' ),
+      ('awesome-joe', 3, 'Bio of Joe');
+
+      insert into articles (author_id, title) values
+      (1, 'janes-novel-first-volume'),
+      (1, 'janes-novel-second-volume'),
+      (2, 'joes-first-series-of-stories'),
+      (2, 'joes-second-series-of-stories'),
+      (2, 'joes-third-series-of-stories')
+
+- type: create_select_permission
+  args:
+    role: user
+    table:
+      name: profiles
+      schema: public
+    permission:
+      columns:
+      - alias
+      - name
+      - id
+      filter:
+        id:
+          _eq: X-Hasura-User-Id
+      limit: null
+      allow_aggregations: false
+
+#user2 do not have select permission on column id
+- type: create_select_permission
+  args:
+    role: user2
+    table:
+      name: profiles
+      schema: public
+    permission:
+      columns:
+      - alias
+      - name
+      filter:
+        id:
+          _eq: X-Hasura-User-Id
+      limit: null
+      allow_aggregations: false

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_array.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_array.yaml
@@ -1,0 +1,13 @@
+type: create_remote_relationship
+args:
+  name: messages
+  table: profiles
+  hasura_fields:
+    - id
+  remote_schema: my-remote-schema
+  remote_field:
+    messages:
+      arguments:
+        where:
+          id:
+            eq: ["$id"]

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_hasura_field.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_hasura_field.yaml
@@ -1,0 +1,11 @@
+type: create_remote_relationship
+args:
+  name: InvalidHasuraField
+  table: profiles
+  hasura_fields:
+    - id_wrong
+  remote_schema: user
+  remote_field:
+    user:
+      arguments:
+        id: "$id_wrong"

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_literal.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_literal.yaml
@@ -1,0 +1,12 @@
+type: create_remote_relationship
+args:
+  name: message
+  table: profiles
+  hasura_fields:
+    - id
+    - name
+  remote_schema: prefixer-proxy
+  remote_field:
+    prefixer_proxy_messages_by_pk:
+      arguments:
+        id: "abc"

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_nested_args.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_nested_args.yaml
@@ -1,0 +1,13 @@
+type: create_remote_relationship
+args:
+  name: messagesNested
+  table: profiles
+  hasura_fields:
+    - id
+  remote_schema: my-remote-schema
+  remote_field:
+    messages:
+      arguments:
+        where:
+          id:
+            xyz: "$id"

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_remote_args.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_remote_args.yaml
@@ -1,0 +1,11 @@
+type: create_remote_relationship
+args:
+  name: invalRemoteArg
+  table: profiles
+  hasura_fields:
+    - id
+  remote_schema: user
+  remote_field:
+    user:
+      arguments:
+        id_wrong: "$id"

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_remote_field.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_remote_field.yaml
@@ -1,0 +1,11 @@
+type: create_remote_relationship
+args:
+  name: invalideRemoteFld
+  table: profiles
+  hasura_fields:
+  - id
+  remote_schema: user
+  remote_field:
+    user_wrong:
+      arguments:
+        id: "$id"

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_remote_schema.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_remote_schema.yaml
@@ -1,0 +1,11 @@
+type: create_remote_relationship
+args:
+  name: invalidRemoteSchema
+  table: profiles
+  hasura_fields:
+    - id
+  remote_schema: user-wrong
+  remote_field:
+    user:
+      arguments:
+        id: "$id"

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_type.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_type.yaml
@@ -1,0 +1,11 @@
+type: create_remote_relationship
+args:
+  name: invalideRemoteRelType
+  table: profiles
+  hasura_fields:
+  - id
+  remote_schema: user
+  remote_field:
+    user:
+      arguments:
+        id: $name

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_variable.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_invalid_remote_rel_variable.yaml
@@ -1,0 +1,11 @@
+type: create_remote_relationship
+args:
+  name: invalidVariable
+  table: profiles
+  hasura_fields:
+    - id
+  remote_schema: user
+  remote_field:
+    user:
+      arguments:
+        id: "$id_wrong"

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_arg_with_arr_structure.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_arg_with_arr_structure.yaml
@@ -1,0 +1,18 @@
+type: create_remote_relationship
+args:
+  name: messagesMultiFields
+  table: authors
+  hasura_fields:
+    - user_id
+    - alias
+  remote_schema: prefixer-proxy
+  remote_field:
+    prefixer_proxy_messages:
+      arguments:
+        where:
+          _and:
+          - profile_id:
+              _eq: $user_id
+          - profile:
+              alias:
+                _eq: $alias

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_array.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_array.yaml
@@ -1,0 +1,13 @@
+type: create_remote_relationship
+args:
+  name: usersNestedArr
+  table: messages
+  hasura_fields:
+    - profile_id
+  remote_schema: prefixer-proxy
+  remote_field:
+    prefixer_proxy_users:
+      arguments:
+        where:
+          id:
+            _in: [$profile_id]

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_basic.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_basic.yaml
@@ -1,0 +1,11 @@
+type: create_remote_relationship
+args:
+  name: userBasic
+  table: profiles
+  hasura_fields:
+    - id
+  remote_schema: user
+  remote_field:
+    user:
+      arguments:
+        id: $id

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_enum_arg.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_enum_arg.yaml
@@ -1,0 +1,16 @@
+type: create_remote_relationship
+args:
+  name: messagesAndBoolExp
+  table: authors
+  hasura_fields:
+    - user_id
+    - alias
+  remote_schema: prefixer-proxy
+  remote_field:
+    prefixer_proxy_messages:
+      arguments:
+        where:
+          profile_id:
+            _eq: $user_id
+        order_by:
+          id: asc

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_err_non_admin_role.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_err_non_admin_role.yaml
@@ -1,0 +1,22 @@
+description: Create remote relationship error non-admin role
+url: /v1/query
+status: 400  
+headers:
+  X-Hasura-User-Id: '1'
+  X-Hasura-Role: user  
+response:
+  path: $.args
+  error: 'restricted access : admin only'
+  code: access-denied
+query:
+  type: create_remote_relationship
+  args:
+    name: userBasic
+    table: profiles
+    hasura_fields:
+      - id
+    remote_schema: user
+    remote_field:
+      user:
+        arguments:
+          id: $id

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_multiple_fields.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_multiple_fields.yaml
@@ -1,0 +1,17 @@
+type: create_remote_relationship
+args:
+  name: messagesMultipleFields
+  table: authors
+  hasura_fields:
+    - user_id
+    - alias
+  remote_schema: prefixer-proxy
+  remote_field:
+    prefixer_proxy_messages:
+      arguments:
+        where:
+          profile_id:
+            _eq: $user_id
+          profile:
+            alias:
+              _eq: $alias

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_nested_args.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_nested_args.yaml
@@ -1,0 +1,13 @@
+type: create_remote_relationship
+args:
+  name: usersNestedArgs
+  table: profiles
+  hasura_fields:
+    - id
+  remote_schema: prefixer-proxy
+  remote_field:
+    prefixer_proxy_users:
+      arguments:
+        where:
+          id:
+            _eq: "$id"

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_nested_fields.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_nested_fields.yaml
@@ -1,0 +1,18 @@
+type: create_remote_relationship
+args:
+  name: authorsNestedMessages
+  table: authors
+  hasura_fields:
+    - user_id
+  remote_schema: prefixer-proxy
+  remote_field:
+    prefixer_proxy_profiles_by_pk:
+      arguments:
+        id : $user_id
+      field:
+        messages:
+          arguments:
+            limit: 10
+            where:
+              profile_id:
+                _eq: $user_id

--- a/server/tests-py/queries/remote_schemas/remote_relationships/teardown.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/teardown.yaml
@@ -1,0 +1,11 @@
+type: bulk
+args:
+- type: run_sql
+  args:
+    sql: |
+      drop table articles cascade;
+      drop table authors cascade;
+      drop table messages cascade;
+      drop table profiles cascade;
+      drop table users cascade;
+    cascade: true

--- a/server/tests-py/queries/remote_schemas/tbls_setup.yaml
+++ b/server/tests-py/queries/remote_schemas/tbls_setup.yaml
@@ -19,5 +19,5 @@ args:
     name: simple2-graphql
     comment: testing
     definition:
-      url: http://localhost:5000/user-graphql
+      url: ${REMOTE_GRAPHQL_ROOT_URL}/user-graphql
       forward_client_headers: false

--- a/server/tests-py/queries/v1/metadata/replace_metadata.yaml
+++ b/server/tests-py/queries/v1/metadata/replace_metadata.yaml
@@ -10,7 +10,7 @@ query:
     - name: test
       comment: testing replace metadata with remote schemas
       definition:
-        url: http://localhost:5000/hello-graphql
+        url: ${REMOTE_GRAPHQL_ROOT_URL}/hello-graphql
         forward_client_headers: false
     tables:
     - table: author

--- a/server/tests-py/requirements-top-level.txt
+++ b/server/tests-py/requirements-top-level.txt
@@ -8,4 +8,4 @@ websocket-client
 pyjwt >= 1.5.3
 jsondiff
 cryptography
-graphene
+graphene==3.0.dev20190817210753

--- a/server/tests-py/requirements.txt
+++ b/server/tests-py/requirements.txt
@@ -1,4 +1,4 @@
-aniso8601==3.0.2
+aniso8601==7.0.0
 apipkg==1.5
 asn1crypto==0.24.0
 atomicwrites==1.3.0
@@ -8,9 +8,9 @@ cffi==1.12.3
 chardet==3.0.4
 cryptography==2.7
 execnet==1.6.0
-graphene==2.1.3
-graphql-core==2.1
-graphql-relay==0.4.5
+graphene==3.0.dev20190817210753
+graphql-core==3.0.0b0
+graphql-relay==3.0.0a1
 idna==2.8
 importlib-metadata==0.17
 jsondiff==1.1.2

--- a/server/tests-py/test_remote_relationships.py
+++ b/server/tests-py/test_remote_relationships.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+import pytest
+import yaml
+
+from validate import check_query_f
+from test_schema_stitching import add_remote, delete_remote
+
+
+@pytest.fixture(scope='class')
+def remote_get_url(remote_gql_server):
+    def remote_url(path):
+        return remote_gql_server.root_url + path
+    return remote_url
+
+def run_sql(hge_ctx, sql):
+    query = {
+        'type': 'run_sql',
+        'args': {
+            'sql' : sql
+        }
+    }
+    st_code, resp = hge_ctx.v1q(query)
+    assert st_code == 200, resp
+    return resp
+
+
+@pytest.fixture(scope='class')
+def validate_v1q_f(hge_ctx, request):
+    def cvq(f, exp_code = 200):
+        st_code, resp = hge_ctx.v1q_f(request.cls.dir() + f)
+        assert st_code == exp_code, {
+            'response': resp,
+            'file' : f
+        }
+        return (st_code, resp)
+    return cvq
+
+
+class TestCreateRemoteRelationship:
+
+    @classmethod
+    def dir(cls):
+        return "queries/remote_schemas/remote_relationships/"
+
+    remote_schemas = {
+        'user' : '/user-graphql',
+        'prefixer-proxy': '/graphql-prefixer-proxy'
+    }
+
+    @pytest.fixture(autouse=True, scope='class')
+    def db_state(self, hge_ctx, remote_get_url, validate_v1q_f):
+        validate_v1q_f('setup.yaml')
+        for (schema, path) in self.remote_schemas.items():
+            add_remote(hge_ctx, schema, remote_get_url(path))
+        yield
+        for schema in self.remote_schemas:
+            delete_remote(hge_ctx, schema)
+        validate_v1q_f('teardown.yaml')
+
+    def test_create_basic(self, validate_v1q_f):
+        validate_v1q_f('setup_remote_rel_basic.yaml')
+
+    def test_create_nested(self, validate_v1q_f):
+        validate_v1q_f('setup_remote_rel_nested_args.yaml')
+
+    def test_create_with_array(self, validate_v1q_f):
+        validate_v1q_f('setup_remote_rel_array.yaml')
+
+    def test_create_nested_fields(self, validate_v1q_f):
+        validate_v1q_f('setup_remote_rel_nested_fields.yaml')
+
+    def test_create_multiple_hasura_fields(self, validate_v1q_f):
+        validate_v1q_f('setup_remote_rel_multiple_fields.yaml')
+
+    @pytest.mark.xfail(reason="Refer https://github.com/tirumaraiselvan/graphql-engine/issues/53")
+    def test_create_arg_with_arr_struture(self, validate_v1q_f):
+        validate_v1q_f('setup_remote_rel_arg_with_arr_structure.yaml')
+
+    @pytest.mark.xfail(reason="Refer https://github.com/tirumaraiselvan/graphql-engine/issues/15")
+    def test_create_enum_arg(self, validate_v1q_f):
+        validate_v1q_f('setup_remote_rel_enum_arg.yaml')
+
+    # st_code, resp = hge_ctx.v1q_f(self.dir() + 'setup_remote_rel_with_interface.yaml')
+    # assert st_code == 200, resp
+
+    def test_create_error_non_admin_role(self, hge_ctx):
+        check_query_f(hge_ctx, self.dir() + 'setup_remote_rel_err_non_admin_role.yaml')
+
+    def test_create_invalid_hasura_field(self, validate_v1q_f):
+        validate_v1q_f('setup_invalid_remote_rel_hasura_field.yaml', 400)
+
+    def test_create_invalid_remote_rel_arg_literal(self, validate_v1q_f):
+        """Test with input argument literal not having the required type"""
+        validate_v1q_f('setup_invalid_remote_rel_literal.yaml', 400)
+
+    def test_create_invalid_remote_rel_variable(self, validate_v1q_f):
+        validate_v1q_f('setup_invalid_remote_rel_variable.yaml', 400)
+
+    def test_create_invalid_remote_args(self, validate_v1q_f):
+        validate_v1q_f('setup_invalid_remote_rel_remote_args.yaml', 400)
+
+    def test_create_invalid_remote_schema(self, validate_v1q_f):
+        validate_v1q_f('setup_invalid_remote_rel_remote_schema.yaml', 400)
+
+    def test_create_invalid_remote_field(self, validate_v1q_f):
+        validate_v1q_f('setup_invalid_remote_rel_remote_field.yaml', 400)
+
+    def test_create_invalid_remote_rel_type(self, validate_v1q_f):
+        validate_v1q_f('setup_invalid_remote_rel_type.yaml', 400)
+
+    def test_create_invalid_remote_rel_nested_args(self, validate_v1q_f):
+        validate_v1q_f('setup_invalid_remote_rel_nested_args.yaml', 400)
+
+    def test_create_invalid_remote_rel_array(self, validate_v1q_f):
+        validate_v1q_f('setup_invalid_remote_rel_array.yaml', 400)

--- a/server/tests-py/test_v1_queries.py
+++ b/server/tests-py/test_v1_queries.py
@@ -1,6 +1,7 @@
 import yaml
 from validate import check_query_f
 from super_classes import DefaultTestSelectQueries, DefaultTestQueries, DefaultTestMutations
+import pytest
 
 class TestDropNoColsTable:
     def test_drop_no_cols_table(self, hge_ctx):
@@ -455,7 +456,7 @@ class TestV1Delete(DefaultTestQueries):
     def dir(cls):
         return "queries/v1/delete"
 
-
+@pytest.mark.usefixtures('remote_gql_server')
 class TestMetadata(DefaultTestQueries):
 
     def test_reload_metadata(self, hge_ctx):

--- a/server/tests-py/validate.py
+++ b/server/tests-py/validate.py
@@ -8,6 +8,7 @@ import jsondiff
 import jwt
 import random
 import time
+import yaml_utils
 
 from context import GQLWsClient
 
@@ -74,7 +75,7 @@ def test_forbidden_when_admin_secret_reqd(hge_ctx, conf):
     # Test without admin secret
     code, resp = hge_ctx.anyq(conf['url'], conf['query'], headers)
     #assert code in [401,404], "\n" + yaml.dump({
-    assert code in status, "\n" + yaml.dump({
+    assert code in status, "\n" + yaml_utils.dump({
         "expected": "Should be access denied as admin secret is not provided",
         "actual": {
             "code": code,
@@ -86,7 +87,7 @@ def test_forbidden_when_admin_secret_reqd(hge_ctx, conf):
     headers['X-Hasura-Admin-Secret'] = base64.b64encode(os.urandom(30))
     code, resp = hge_ctx.anyq(conf['url'], conf['query'], headers)
     #assert code in [401,404], "\n" + yaml.dump({
-    assert code in status, "\n" + yaml.dump({
+    assert code in status, "\n" + yaml_utils.dump({
         "expected": "Should be access denied as an incorrect admin secret is provided",
         "actual": {
             "code": code,
@@ -107,7 +108,7 @@ def test_forbidden_webhook(hge_ctx, conf):
     h = {'Authorization': 'Bearer ' + base64.b64encode(base64.b64encode(os.urandom(30))).decode('utf-8')}
     code, resp = hge_ctx.anyq(conf['url'], conf['query'], h)
     #assert code in [401,404], "\n" + yaml.dump({
-    assert code in status, "\n" + yaml.dump({
+    assert code in status, "\n" + yaml_utils.dump({
         "expected": "Should be access denied as it is denied from webhook",
         "actual": {
             "code": code,
@@ -218,7 +219,7 @@ def validate_gql_ws_q(hge_ctx, endpoint, query, headers, exp_http_response, retr
     exp_ws_response = exp_http_response
 
     assert 'payload' in resp, resp
-    assert resp['payload'] == exp_ws_response, yaml.dump({
+    assert resp['payload'] == exp_ws_response, yaml_utils.dump({
         'response': resp['payload'],
         'expected': exp_ws_response,
         'diff': jsondiff.diff(exp_ws_response, resp['payload'])
@@ -234,7 +235,7 @@ def validate_http_anyq(hge_ctx, url, query, headers, exp_code, exp_response):
     assert code == exp_code, resp
     print('http resp: ', resp)
     if exp_response:
-        assert json_ordered(resp) == json_ordered(exp_response), yaml.dump({
+        assert json_ordered(resp) == json_ordered(exp_response), yaml_utils.dump({
             'response': resp,
             'expected': exp_response,
             'diff': jsondiff.diff(exp_response, resp)
@@ -246,7 +247,7 @@ def check_query_f(hge_ctx, f, transport='http', add_auth=True):
     hge_ctx.may_skip_test_teardown = False
     print ("transport="+transport)
     with open(f) as c:
-        conf = yaml.safe_load(c)
+        conf = yaml_utils.load(c)
         if isinstance(conf, list):
             for sconf in conf:
                 check_query(hge_ctx, sconf, transport, add_auth)

--- a/server/tests-py/yaml_utils.py
+++ b/server/tests-py/yaml_utils.py
@@ -1,0 +1,42 @@
+import yaml
+import re
+import os
+
+# Match '${env_name}'
+path_matcher = re.compile(r'\$\{([^}^{]+)\}')
+
+def path_constructor(loader, node):
+    ''' 
+    Extract the name of the environmental variable, 
+    and replace it with its value
+    '''
+    value = node.value
+    match = path_matcher.match(value)
+    env_var = match.group()[2:-1]
+    return os.environ[env_var] + value[match.end():]
+
+def yaml_process_env_vars_conf():
+    '''
+    Add resolver and constructor required for 
+    processing environmental vairables in yaml
+    '''
+    yaml.add_implicit_resolver('!env', path_matcher, None, yaml.SafeLoader)
+    yaml.add_constructor('!env', path_constructor, yaml.SafeLoader)
+
+yaml_process_env_vars_conf()
+
+def load(f):
+    '''Perform safe load'''
+    return yaml.safe_load(f)
+
+def dump(o):
+    '''Dump yaml without aliases'''
+    return yaml.dump(o, Dumper=ExplicitDumper)
+
+class ExplicitDumper(yaml.SafeDumper):
+    """
+    A dumper that will never emit aliases.
+    """
+
+    def ignore_aliases(self, data):
+        return True


### PR DESCRIPTION
1) Tests for creation of remote relationships
2) Run a GraphQL server per test thread
3) GraphQL proxy which sets a prefix to the types and top-level fields of the schema, and thus can be added a remote.

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Affected components 
<!-- Remove non-affected components from the list -->

- Server
- Console
- CLI
- Docs
- Community Content
- Build System
- Tests
- Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->

<!-- Feel free to delete these comment lines -->
