### PR TITLE
Lots of refactors and documentation

### DIFF
--- a/server/src-lib/Hasura/Db.hs
+++ b/server/src-lib/Hasura/Db.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 -- A module for postgres execution related types and operations
 
 module Hasura.Db
@@ -49,6 +50,11 @@ data LazyTx e a
   = LTErr !e
   | LTNoTx !a
   | LTTx !(Q.TxE e a)
+  deriving Show
+
+-- orphan:
+instance Show (Q.TxE e a) where
+  show = const "(error \"TxE\")"
 
 lazyTxToQTx :: LazyTx e a -> Q.TxE e a
 lazyTxToQTx = \case

--- a/server/src-lib/Hasura/GraphQL/Execute.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute.hs
@@ -76,8 +76,8 @@ data QExecPlanResolved
 
 
 -- | Split the 'rrSelSet' from the 'RemoteRelBranch'
-mkQuery :: G.OperationType -> JoinArguments -> QExecPlanUnresolved -> (RemoteRelBranch 'RRF_Splice, VQ.RemoteTopField)
-mkQuery rtqOperationType JoinArguments{..} QExecPlanUnresolved{..}  =
+mkQuery :: G.OperationType -> QExecPlanUnresolved -> JoinArguments -> (RemoteRelBranch 'RRF_Splice, VQ.RemoteTopField)
+mkQuery rtqOperationType QExecPlanUnresolved{..} JoinArguments{..} =
   let RemoteRelBranch{..} = remoteRelField
       indexedRows = enumerateRowAliases $ toList joinArguments
       rtqFields =

--- a/server/src-lib/Hasura/GraphQL/Execute.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute.hs
@@ -94,7 +94,7 @@ mkQuery rtqOperationType BatchInputs{..} QExecPlanUnresolved{..}  =
              variables
              rrSelSet
              alias
-             (rtrRemoteFields $ rmfRemoteRelationship rrRemoteField)
+             (rtrRemoteFields rrRemoteRelationship)
    in (produceBatch remoteRelField biCardinality, VQ.RemoteTopField{..})
     
 
@@ -255,8 +255,7 @@ getExecPlan pgExecCtx planCache userInfo@UserInfo{..} sqlGenCtx enableAL sc scVe
         getRsi remoteRel =
           case Map.lookup
                  (rtrRemoteSchema
-                    (rmfRemoteRelationship
-                       (rrRemoteField remoteRel)))
+                    (rrRemoteRelationship remoteRel))
                  (scRemoteSchemas sc) of
             Just remoteSchemaCtx -> pure $ rscInfo remoteSchemaCtx
             Nothing -> throw500 "could not find remote schema info"

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery.hs
@@ -99,6 +99,7 @@ initLiveQueriesState (LQOpts mxOpts fallbackOpts) pgExecCtx = do
 data LiveQueryOp
   = LQMultiplexed !LQM.MxOp
   | LQFallback !LQF.FallbackOp
+  deriving Show
 
 data LiveQueryId
   = LQIMultiplexed !LQM.LiveQueryId

--- a/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Multiplexed.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/LiveQuery/Multiplexed.hs
@@ -259,6 +259,7 @@ data MxOpCtx
   , _mocAlias     :: !G.Alias
   , _mocQuery     :: !Q.Query
   }
+  deriving Show
 
 instance J.ToJSON MxOpCtx where
   toJSON (MxOpCtx lqGroup als q) =

--- a/server/src-lib/Hasura/GraphQL/Execute/Query.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/Query.hs
@@ -261,6 +261,7 @@ data PreparedSql
   { _psQuery    :: !Q.Query
   , _psPrepArgs :: ![Q.PrepArg]
   }
+  deriving Show
 
 -- | Required to log in `query-log`
 instance J.ToJSON PreparedSql where

--- a/server/src-lib/Hasura/GraphQL/Execute/RemoteJoins.hs
+++ b/server/src-lib/Hasura/GraphQL/Execute/RemoteJoins.hs
@@ -127,19 +127,17 @@ bareNamedField _fName =
 
 
 -- | Rebuild the query tree, returning a new tree with remote relationships
--- removed, along with a list of paths that point back to them.
---
--- 'Nothing' means there were no remote fields.
+-- removed, along with a (possibly empty) list of paths that point back to them.
 --
 -- Output here is eventually assembled into a 'QExecPlan' 'Tree' in
 -- 'getExecPlan', and finally executed in 'runGQ'.
 rebuildFieldStrippingRemoteRels
   :: VQ.Field 
-  -> Maybe (VQ.Field, NonEmpty (RemoteRelBranch 'RRF_Tree))
-  -- ^ NOTE: the ordering of the _fSelSet fields in the result 'VQ.Field' seems not to matter at 
+  -> (VQ.Field, [RemoteRelBranch 'RRF_Tree])
+  -- NOTE: the ordering of the _fSelSet fields in the result 'VQ.Field' seems not to matter at 
   -- all for correctness here (based on experimentation)... I haven't puzzled out why yet.
 rebuildFieldStrippingRemoteRels =
-  traverse NE.nonEmpty . flip runState mempty . rebuild 0 mempty
+  flip runState mempty . rebuild 0 mempty
   where
     rebuild :: Int -> RelFieldPath -> Field -> State [RemoteRelBranch 'RRF_Tree] Field
     rebuild idx0 parentPath field0 = do

--- a/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/HTTP.hs
@@ -111,7 +111,7 @@ runHasuraGQ reqId query userInfo resolvedOp = do
   resp <- liftEither respE
   return $ encodeGQResp $ GQSuccess resp
 
-
+-- | See 'mergeResponseData'.
 getMergedGQResp :: Traversable t=> t EncJSON -> Either String GQRespValue
 getMergedGQResp =
   mergeGQResp <=< traverse E.parseGQRespValue
@@ -119,6 +119,8 @@ getMergedGQResp =
           respAcc & E.gqRespErrors <>~ _gqRespErrors
                   & mapMOf E.gqRespData (OJ.safeUnion _gqRespData)
 
+-- | Union several graphql responses, with the ordering of the top-level fields
+-- determined by the input list.
 mergeResponseData :: Traversable t=> t EncJSON -> Either String EncJSON
 mergeResponseData =
   fmap E.encodeGQRespValue . getMergedGQResp

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -304,7 +304,7 @@ onStart serverEnv wsConn (StartMsg opId q) =
           runExceptT $ do
             flip mapM execPlans $ \execPlan ->
               case execPlan of
-                E.Leaf plan ->
+                ([], plan) ->
                   case plan of
                     E.ExPHasura operation ->
                       case operation of
@@ -323,7 +323,7 @@ onStart serverEnv wsConn (StartMsg opId q) =
                                "did not expect subscription operation here")
                     E.ExPRemote rtf ->
                       runRemoteGQ execCtx requestId userInfo reqHdrs rtf
-                E.Tree {} ->
+                _ ->
                   throwError
                     (err400
                        NotSupported
@@ -357,7 +357,7 @@ onStart serverEnv wsConn (StartMsg opId q) =
       where
         getLeafPlan =
           \case
-            E.Leaf resolvedPlan ->
+            ([], resolvedPlan) ->
               case resolvedPlan of
                 E.ExPHasura operation -> Just operation
                 E.ExPRemote _         -> Nothing

--- a/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
+++ b/server/src-lib/Hasura/GraphQL/Transport/WebSocket.hs
@@ -392,26 +392,24 @@ onStart serverEnv wsConn (StartMsg opId q) =
       -> [H.Header]
       -> VQ.RemoteTopField
       -> m EncJSON
-    runRemoteGQ execCtx reqId userInfo reqHdrs topField
+    runRemoteGQ execCtx reqId userInfo reqHdrs RemoteTopField{..}
       -- if it's not a subscription, use HTTP to execute the query on the remote
       -- server
       -- try to parse the (apollo protocol) websocket frame and get only the
       -- payload
      = do
-      when (rtqOperationType topField == G.OperationTypeSubscription) $
+      when (rtqOperationType == G.OperationTypeSubscription) $
         throwError $
         err400 NotSupported "subscription to remote server is not supported"
-      resp <-
-        let (rsi, fields) = remoteTopQueryEither topField
-         in runExceptT $
-            flip runReaderT execCtx $
-            E.execRemoteGQ
-              reqId
-              userInfo
-              reqHdrs
-              (rtqOperationType topField)
-              rsi
-              fields
+      resp <- runExceptT $
+              flip runReaderT execCtx $
+              E.execRemoteGQ
+                reqId
+                userInfo
+                reqHdrs
+                rtqOperationType
+                rtqRemoteSchemaInfo
+                (Right rtqFields)
       liftEither (fmap _hrBody resp)
     WSServerEnv logger pgExecCtx lqMap gCtxMapRef httpMgr _ sqlGenCtx planCache _ enableAL =
       serverEnv

--- a/server/src-lib/Hasura/GraphQL/Validate.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate.hs
@@ -1,6 +1,5 @@
 module Hasura.GraphQL.Validate
   ( validateGQ
-  , remoteTopQueryEither
   , showVars
   , LocatedTopField(..)
   , HasuraTopField(..)
@@ -170,9 +169,6 @@ data HasuraTopField
   | HasuraTopMutation !Field
   | HasuraTopSubscription !Field
   deriving (Show, Eq)
-
-remoteTopQueryEither :: RemoteTopField -> (RemoteSchemaInfo, Either a [Field])
-remoteTopQueryEither (RemoteTopField remoteSchemaInfo fields _op) = (remoteSchemaInfo, pure fields)
 
 data RemoteTopField =
   RemoteTopField

--- a/server/src-lib/Hasura/GraphQL/Validate/Field.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/Field.hs
@@ -1,6 +1,6 @@
 module Hasura.GraphQL.Validate.Field
   ( ArgsMap
-  , Field(..)
+  , Field(..), fAlias, fName, fType, fArguments, fSelSet, fRemoteRel
   , SelSet
   , Located(..)
   , denormSelSet
@@ -8,6 +8,7 @@ module Hasura.GraphQL.Validate.Field
 
 import           Hasura.Prelude
 
+import           Control.Lens
 import qualified Data.Aeson                          as J
 import qualified Data.Aeson.Casing                   as J
 import qualified Data.Aeson.TH                       as J
@@ -49,13 +50,15 @@ type ArgsMap = Map.HashMap G.Name AnnInpVal
 
 type SelSet = Seq.Seq Field
 
--- N.B. This is a tree via 'SelSet'
 -- | https://graphql.github.io/graphql-spec/June2018/#sec-Language.Fields 
+--
+-- N.B. This is a tree via 'SelSet'
 data Field
   = Field
   { _fAlias     :: !G.Alias
   , _fName      :: !G.Name
   , _fType      :: !G.NamedType
+  -- ^ TODO: this seems to get initialized to "unknown.."; how is this used? Document or improve.
   , _fArguments :: !ArgsMap
   , _fSelSet    :: !SelSet
   , _fRemoteRel :: !(Maybe RemoteField)
@@ -64,6 +67,7 @@ data Field
 $(J.deriveToJSON (J.aesonDrop 2 J.camelCase){J.omitNothingFields=True}
   ''Field
  )
+makeLenses ''Field
 
 -- newtype FieldMapAlias
 --   = FieldMapAlias

--- a/server/src-lib/Hasura/GraphQL/Validate/Field.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/Field.hs
@@ -58,7 +58,6 @@ data Field
   { _fAlias     :: !G.Alias
   , _fName      :: !G.Name
   , _fType      :: !G.NamedType
-  -- ^ TODO: this seems to get initialized to "unknown.."; how is this used? Document or improve.
   , _fArguments :: !ArgsMap
   , _fSelSet    :: !SelSet
   , _fRemoteRel :: !(Maybe RemoteField)

--- a/server/src-lib/Hasura/GraphQL/Validate/Types.hs
+++ b/server/src-lib/Hasura/GraphQL/Validate/Types.hs
@@ -658,6 +658,7 @@ type FragDefMap = Map.HashMap G.Name FragDef
 type AnnVarVals =
   Map.HashMap G.Variable AnnInpVal
 
+-- TODO document me
 data AnnInpVal
   = AnnInpVal
   { _aivType     :: !G.GType

--- a/server/src-lib/Hasura/Prelude.hs
+++ b/server/src-lib/Hasura/Prelude.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 module Hasura.Prelude
   ( module M
   , onNothing
@@ -7,6 +8,9 @@ module Hasura.Prelude
   , bsToTxt
   , txtToBs
   , spanMaybeM
+  -- * Efficient coercions
+  , coerce
+  , coerceSet
   ) where
 
 import           Control.Applicative        as M (Alternative (..))
@@ -43,8 +47,11 @@ import           Data.Word                  as M (Word64)
 import           GHC.Generics               as M (Generic)
 import           Prelude                    as M hiding (fail, init, lookup)
 import           Text.Read                  as M (readEither, readMaybe)
+import           Unsafe.Coerce
 
 import qualified Data.ByteString            as B
+import           Data.Coerce
+import qualified Data.Set                   as Set
 import qualified Data.Text.Encoding         as TE
 import qualified Data.Text.Encoding.Error   as TE
 
@@ -76,3 +83,13 @@ spanMaybeM f = go . toList
     go l@(x:xs) = f x >>= \case
       Just y  -> first (y:) <$> go xs
       Nothing -> pure ([], l)
+
+-- | Efficiently coerce a set from one type to another.
+--
+-- This has the same safety properties as 'Set.mapMonotonic', and is equivalent
+-- to @Set.mapMonotonic coerce@ but is more efficient. This is safe to use when
+-- both @a@ and @b@ have automatically derived @Ord@ instances.
+--
+-- https://stackoverflow.com/q/57963881/176841
+coerceSet :: Coercible a b=> Set.Set a -> Set.Set b
+coerceSet = unsafeCoerce

--- a/server/src-lib/Hasura/RQL/DDL/RemoteRelationship/Validate.hs
+++ b/server/src-lib/Hasura/RQL/DDL/RemoteRelationship/Validate.hs
@@ -26,6 +26,7 @@ import qualified Hasura.GraphQL.Context        as GC
 import qualified Hasura.GraphQL.Schema         as GS
 import qualified Language.GraphQL.Draft.Syntax as G
 
+-- TODO pretty-print readable errors:
 -- | An error validating the remote relationship.
 data ValidationError
   = CouldntFindRemoteField G.Name ObjTyInfo

--- a/server/src-lib/Hasura/RQL/Types/RemoteRelationship.hs
+++ b/server/src-lib/Hasura/RQL/Types/RemoteRelationship.hs
@@ -108,8 +108,8 @@ parseRemoteArguments j =
     _                -> fail "Remote arguments should be an object of keys."
 
 -- | For some 'FieldCall', for instance, associates a field argument name with
--- either a scalar value or some 'G.Variable' we are closed over (brought into
--- scope, e.g. in 'rtrHasuraFields'.
+-- either a list of either scalar values or some 'G.Variable' we are closed
+-- over (brought into scope, e.g. in 'rtrHasuraFields'.
 newtype RemoteArguments =
   RemoteArguments
     { getRemoteArguments :: [G.ObjectFieldG G.Value]
@@ -121,7 +121,9 @@ instance ToJSON RemoteArguments where
 instance FromJSON RemoteArguments where
   parseJSON = parseRemoteArguments
 
--- | https://graphql.github.io/graphql-spec/June2018/#sec-Language.Arguments 
+-- | Associates a field name with the arguments it will be passed in the query.
+--
+-- https://graphql.github.io/graphql-spec/June2018/#sec-Language.Arguments 
 --
 -- TODO we don't seem to support empty RemoteArguments (like 'hello'), but this seems arbitrary:
 data FieldCall =

--- a/server/src-lib/Hasura/RQL/Types/RemoteRelationship.hs
+++ b/server/src-lib/Hasura/RQL/Types/RemoteRelationship.hs
@@ -34,6 +34,8 @@ data RemoteField =
     -- can reference multiple remote field calls, no?
     , rmfGType              :: !G.GType
     , rmfParamMap           :: !(HashMap G.Name InpValInfo)
+    -- ^ Fully resolved arguments (no variable references, since this uses
+    -- 'G.ValueConst' not 'G.Value').
     }
   deriving (Show, Eq, Lift)
 
@@ -45,11 +47,10 @@ data RemoteRelationship =
     , rtrTable        :: QualifiedTable
     , rtrHasuraFields :: Set FieldName -- TODO? change to PGCol
     -- ^ The hasura fields from 'rtrTable' that will be in scope when resolving
-    -- the remote object.
+    -- the remote objects in 'rtrRemoteFields'.
     , rtrRemoteSchema :: RemoteSchemaName
     -- ^ Identifier for this mapping.
     , rtrRemoteFields :: NonEmpty FieldCall
-    -- ^ In these remote field calls
     }  deriving (Show, Eq, Lift)
 
 -- Parsing GraphQL input arguments from JSON

--- a/server/src-lib/Hasura/Server/Context.hs
+++ b/server/src-lib/Hasura/Server/Context.hs
@@ -17,4 +17,4 @@ data HttpResponse a
   = HttpResponse
   { _hrBody    :: !a
   , _hrHeaders :: !(Maybe Headers)
-  }
+  } deriving (Functor, Foldable, Traversable)

--- a/server/tests-py/queries/remote_schemas/remote_relationships/basic_relationship_with_permissions1.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/basic_relationship_with_permissions1.yaml
@@ -1,22 +1,44 @@
-description: Simple remote relationship GraphQL query
-url: /v1/graphql
-status: 200
-headers:
-  X-Hasura-Role: user
-  X-Hasura-User-Id: '1'
-response:
-  data:
-    profiles:
-      - id: 1
-        messageBasic:
-          name: alice
-query:
-  query: |
-    query {
-      profiles {
-        id
-        messageBasic {
-          name
+- description: Simple remote relationship query with permissions
+  url: /v1/graphql
+  status: 200
+  headers:
+    X-Hasura-Role: user
+    X-Hasura-User-Id: '1'
+  response:
+    data:
+      profiles:
+        - id: 1
+          messageBasic:
+            name: alice
+  query:
+    query: |
+      query {
+        profiles {
+          id
+          messageBasic {
+            name
+          }
         }
       }
-    }
+- description: Simple remote relationship query with permissions
+  url: /v1/graphql
+  status: 200
+  headers:
+    X-Hasura-Role: user
+    X-Hasura-User-Id: '2'
+  response:
+    data:
+      profiles:
+        - id: 2
+          messageBasic:
+            name: bob
+  query:
+    query: |
+      query {
+        profiles {
+          id
+          messageBasic {
+            name
+          }
+        }
+      }

--- a/server/tests-py/queries/remote_schemas/remote_relationships/basic_relationship_with_permissions2.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/basic_relationship_with_permissions2.yaml
@@ -1,4 +1,4 @@
-description: Simple remote relationship GraphQL query
+description: Simple remote relationship query with permissions, unauthorized
 url: /v1/graphql
 status: 200
 headers:

--- a/server/tests-py/queries/remote_schemas/remote_relationships/complex_multiple_joins.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/complex_multiple_joins.yaml
@@ -1,0 +1,192 @@
+# NOTE: this would also be a good query to benchmark concurrency and haxl batching/caching
+
+# TODO map to multiple (different?) remote fields in first query (so rtrRemoteFields > 1)
+
+  # Adapted from server/tests-py/queries/remote_schemas/remote_relationships/basic_array.yaml, etc
+- description: Many remote fields, etc
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      p_1:
+        id: 1
+        name: alice
+        remoteUser:
+          user_id: 1
+      profiles:
+        - some_constant_text: constant text
+          messagesNestedArr:
+            - name: alice
+              msg: You win!
+            - name: alice
+              msg: Another alice
+          name: alice
+          r_user:
+            user_id: 1
+        - some_constant_text: constant text
+          messagesNestedArr:
+            - name: bob
+              msg: You lose!
+          name: bob
+          r_user:
+            user_id: 2
+        - some_constant_text: constant text
+          messagesNestedArr:
+            - name: alice
+              msg: You win!
+            - name: alice
+              msg: Another alice
+          name: alice
+          r_user:
+            user_id: 3
+      profiles_by_pk:
+        id: 2
+        name: bob
+        remoteUser:
+          user_id: 2
+  query:
+    query: |
+      query {
+        # A top-level object
+        p_1: profiles_by_pk(id: 1) {
+          id
+          name
+          remoteUser {
+            user_id
+          }
+        }
+        profiles {
+          # no `id`, so becomes rrPhantomFields
+          some_constant_text
+          messagesNestedArr {
+            name
+            msg
+          }
+          name
+          # use alias for kicks:
+          r_user: remoteUser {
+            user_id
+          }
+        }
+        # A top-level object
+        profiles_by_pk(id: 2) {
+          id
+          name
+          remoteUser {
+            user_id
+          }
+        }
+      }
+- description: Many remote fields, etc with permissions, id=1
+  headers:
+    X-Hasura-Role: user
+    X-Hasura-User-Id: '1'
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      p_1:
+        id: 1
+        name: alice
+        remoteUser:
+          user_id: 1
+      profiles:
+        - some_constant_text: constant text
+          messagesNestedArr:
+            - name: alice
+              msg: You win!
+            - name: alice
+              msg: Another alice
+          name: alice
+          r_user:
+            user_id: 1
+      # Not permitted:
+      profiles_by_pk: null
+  query:
+    query: |
+      query {
+        # A top-level object
+        p_1: profiles_by_pk(id: 1) {
+          id
+          name
+          remoteUser {
+            user_id
+          }
+        }
+        profiles {
+          # no `id`, so becomes rrPhantomFields
+          some_constant_text
+          messagesNestedArr {
+            name
+            msg
+          }
+          name
+          # use alias for kicks:
+          r_user: remoteUser {
+            user_id
+          }
+        }
+        # A top-level object (not permitted)
+        profiles_by_pk(id: 2) {
+          id
+          name
+          remoteUser {
+            user_id
+          }
+        }
+      }
+- description: Many remote fields, etc with permissions, id=2
+  headers:
+    X-Hasura-Role: user
+    X-Hasura-User-Id: '2'
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      p_1: null
+      profiles:
+        - some_constant_text: constant text
+          messagesNestedArr:
+            - name: bob
+              msg: You lose!
+          name: bob
+          r_user:
+            user_id: 2
+      profiles_by_pk:
+        id: 2
+        name: bob
+        remoteUser:
+          user_id: 2
+  query:
+    query: |
+      query {
+        # A top-level object
+        p_1: profiles_by_pk(id: 1) {
+          id
+          name
+          remoteUser {
+            user_id
+          }
+        }
+        profiles {
+          # no `id`, so becomes rrPhantomFields
+          some_constant_text
+          messagesNestedArr {
+            name
+            msg
+          }
+          name
+          # use alias for kicks:
+          r_user: remoteUser {
+            user_id
+          }
+        }
+        # A top-level object
+        profiles_by_pk(id: 2) {
+          id
+          name
+          remoteUser {
+            user_id
+          }
+        }
+      }

--- a/server/tests-py/queries/remote_schemas/remote_relationships/complex_multiple_joins.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/complex_multiple_joins.yaml
@@ -2,7 +2,11 @@
 
 # TODO map to multiple (different?) remote fields in first query (so rtrRemoteFields > 1)
 
-  # Adapted from server/tests-py/queries/remote_schemas/remote_relationships/basic_array.yaml, etc
+# This is mostly just a bigger more complex test case useful for seeing how
+# everything fits together, but a few things we specifically want to excercise:
+#  - returning > 1 BatchInputs from `extractRemoteRelArguments`.
+#  - empty hasura_fields (remote not closed over any hasura fields)
+#
 - description: Many remote fields, etc
   url: /v1/graphql
   status: 200
@@ -15,6 +19,7 @@
           user_id: 1
       profiles:
         - some_constant_text: constant text
+          some_more_constant_text: more constant text
           messagesNestedArr:
             - name: alice
               msg: You win!
@@ -24,6 +29,7 @@
           r_user:
             user_id: 1
         - some_constant_text: constant text
+          some_more_constant_text: more constant text
           messagesNestedArr:
             - name: bob
               msg: You lose!
@@ -31,6 +37,7 @@
           r_user:
             user_id: 2
         - some_constant_text: constant text
+          some_more_constant_text: more constant text
           messagesNestedArr:
             - name: alice
               msg: You win!
@@ -55,9 +62,11 @@
             user_id
           }
         }
+        # NOTE: ordering is somewhat important and intentional here (e.g. placement of some_more_constant_text)
         profiles {
           # no `id`, so becomes rrPhantomFields
           some_constant_text
+          some_more_constant_text
           messagesNestedArr {
             name
             msg
@@ -188,5 +197,36 @@
           remoteUser {
             user_id
           }
+        }
+      }
+- description: Empty hasura_fields bug
+  url: /v1/graphql
+  status: 200
+  response:
+    data:
+      profiles:
+        - some_constant_text: constant text
+          some_more_constant_text: more constant text
+          id: 1
+        - some_constant_text: constant text
+          some_more_constant_text: more constant text
+          id: 2
+        - some_constant_text: constant text
+          some_more_constant_text: more constant text
+          id: 3
+      p_1:
+        # some_constant_text: constant text
+        some_more_constant_text: more constant text
+  query:
+    query: |
+      query {
+        profiles {
+          some_constant_text
+          some_more_constant_text
+          id
+        }
+        p_1: profiles_by_pk(id: 1) {
+          # some_constant_text
+          some_more_constant_text
         }
       }

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_multiple_remote_rel.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_multiple_remote_rel.yaml
@@ -45,4 +45,23 @@ args:
             arguments:
               text: constant text
 
+# Note: purposely closed over no hasura fields to make sure our mapping isn't
+# off in code that resolves/reassembles.
+- type: create_remote_relationship
+  args:
+    name: some_more_constant_text
+    table: profiles
+    hasura_fields: []
+    # hasura_fields:
+    # - id
+    remote_schema: my-remote-schema
+    remote_field:
+      user:
+        arguments:
+          user_id: 999
+        field:
+          gimmeText:
+            arguments:
+              text: more constant text
+
 # TODO add top-level thang with NO arguments (hello:)

--- a/server/tests-py/queries/remote_schemas/remote_relationships/setup_multiple_remote_rel.yaml
+++ b/server/tests-py/queries/remote_schemas/remote_relationships/setup_multiple_remote_rel.yaml
@@ -1,0 +1,48 @@
+type: bulk
+args:
+# from setup_remote_rel_basic:
+- type: create_remote_relationship
+  args:
+    name: remoteUser
+    table: profiles
+    hasura_fields:
+      - id
+    remote_schema: my-remote-schema
+    remote_field:
+      user:
+        arguments:
+          user_id: "$id"
+
+# from server/tests-py/queries/remote_schemas/remote_relationships/setup_remote_rel_array.yaml 
+- type: create_remote_relationship
+  args:
+    name: messagesNestedArr
+    table: profiles
+    hasura_fields:
+      - name
+    remote_schema: my-remote-schema
+    remote_field:
+      messages:
+        arguments:
+          includes:
+            name: ["$name"]
+
+- type: create_remote_relationship
+  args:
+    name: some_constant_text
+    table: profiles
+    hasura_fields:
+      # TODO we should probably raise an error for these unused fields:
+      - id
+      - name
+    remote_schema: my-remote-schema
+    remote_field:
+      user:
+        arguments:
+          user_id: 999
+        field:
+          gimmeText:
+            arguments:
+              text: constant text
+
+# TODO add top-level thang with NO arguments (hello:)

--- a/server/tests-py/test_remote_relationships.py
+++ b/server/tests-py/test_remote_relationships.py
@@ -326,3 +326,10 @@ class TestExecutionWithPermissions:
         assert st_code == 200, resp
         check_query_f(hge_ctx, self.dir() + 'basic_relationship_with_permissions1.yaml', transport)
         check_query_f(hge_ctx, self.dir() + 'basic_relationship_with_permissions2.yaml', transport)
+
+    # Test queries that combine several remote relationships, nested in
+    # different ways, variously filtering different bits using permissions.
+    def test_complex_multiple_joins(self, hge_ctx, transport):
+        st_code, resp = hge_ctx.v1q_f(self.dir() + 'setup_multiple_remote_rel.yaml')
+        assert st_code == 200, resp
+        check_query_f(hge_ctx, self.dir() + 'complex_multiple_joins.yaml', transport)


### PR DESCRIPTION
- Remove Joinable class with single instance
- Refactor mkQuery and produceBatch for a little more clarity, so they
  only take and return relevant data.
- Simplify `rebuildFieldStrippingRemoteRels`; there seemed to be some
  unnecessary and also insufficient filtering logic happening here (but
  could use a close review)
- factor out the remote query aliasing/sorting stuff into
  `enumerateRowAliases`, `unEnumerateRowAliases` which we can document
  properly
- Remove some unnecessary fields from Batch; narrowing scope of
  functions that take or return a Batch aids understanding.
- inline stuff into `extractRemoteRelArguments` and refactor
- add `coerceSet` to Hasura.Prelude (this was used several times in a
  previous iteration, now only appears once; I'm not super committed to
  keeping it)
- add some tests, mostly just trying to excercise a few different things
  in the same query and used as an aid to understanding the code