### PR TITLE
add tests for scheduled triggers

### DIFF
--- a/server/tests-py/conftest.py
+++ b/server/tests-py/conftest.py
@@ -267,6 +267,16 @@ def actions_webhook(hge_ctx):
     web_server.join()
 
 @pytest.fixture(scope='class')
+def scheduled_triggers_evts_webhook(request):
+    webhook_httpd = EvtsWebhookServer(server_address=('127.0.0.1', 5594))
+    web_server = threading.Thread(target=webhook_httpd.serve_forever)
+    web_server.start()
+    yield webhook_httpd
+    webhook_httpd.shutdown()
+    webhook_httpd.server_close()
+    web_server.join()
+
+@pytest.fixture(scope='class')
 def ws_client(request, hge_ctx):
     """
     This fixture provides an Apollo GraphQL websockets client

--- a/server/tests-py/context.py
+++ b/server/tests-py/context.py
@@ -351,6 +351,9 @@ class EvtsWebhookServer(http.server.HTTPServer):
             sz = sz + 1
         return sz
 
+    def is_queue_empty(self):
+        return self.resp_queue.empty
+
     def teardown(self):
         self.evt_trggr_httpd.shutdown()
         self.evt_trggr_httpd.server_close()

--- a/server/tests-py/requirements.txt
+++ b/server/tests-py/requirements.txt
@@ -5,6 +5,7 @@ attrs==19.3.0
 certifi==2019.9.11
 cffi==1.13.2
 chardet==3.0.4
+croniter==0.3.31
 cryptography==2.8
 execnet==1.7.1
 graphene==2.1.8

--- a/server/tests-py/test_scheduled_triggers.py
+++ b/server/tests-py/test_scheduled_triggers.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+
+import pytest
+from datetime import datetime,timedelta
+from croniter import croniter
+from validate import validate_event_webhook,validate_event_headers
+from queue import Empty
+import time
+
+def stringify_datetime(dt):
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+def get_events_of_scheduled_trigger(hge_ctx,trigger_name):
+    events_count_sql = '''
+    select count(*) from hdb_catalog.hdb_scheduled_events where name = '{}'
+    '''.format(trigger_name)
+    q = {
+        "type":"run_sql",
+        "args":{
+            "sql":events_count_sql
+        }
+    }
+    return hge_ctx.v1q(q)
+
+class TestScheduledTriggerCron(object):
+
+    cron_trigger_name = "a_scheduled_trigger"
+    webhook_payload = {"foo":"baz"}
+    webhook_path = "/hello"
+    url = '/v1/query'
+
+    def test_create_cron_schedule_triggers(self,hge_ctx):
+        # setting the time zone to 'UTC' because everything
+        # (utcnow,now,cronschedule) will all be based on UTC.
+        q = {
+            "type":"run_sql",
+            "args":{
+                "sql":"set time zone 'UTC'"
+            }
+        }
+        st,resp = hge_ctx.v1q(q)
+        assert st == 200,resp
+        # setting the test to be after 30 mins, to make sure that
+        # any of the events are not triggered.
+        min_after_30_mins = (datetime.utcnow() + timedelta(minutes=30)).minute
+        TestScheduledTriggerCron.cron_schedule = "{} * * * *".format(min_after_30_mins)
+
+        cron_st_api_query = {
+            "type":"create_scheduled_trigger",
+            "args":{
+                "name":self.cron_trigger_name,
+                "webhook":"http://127.0.0.1:5594" + "/foo",
+                "schedule":{
+                    "type":"cron",
+                    "value":self.cron_schedule
+                },
+                "headers":[
+                    {
+                        "name":"foo",
+                        "value":"baz"
+                    }
+                ],
+                "payload":self.webhook_payload
+            }
+        }
+        headers = {}
+        if hge_ctx.hge_key is not None:
+            headers['X-Hasura-Admin-Secret'] = hge_ctx.hge_key
+        cron_st_code,cron_st_resp,_ = hge_ctx.anyq(self.url,cron_st_api_query,headers)
+        TestScheduledTriggerCron.init_time = datetime.utcnow() # the cron events will be generated based on the current time, they will not be exactly the same though(the server now and now here)
+        assert cron_st_code == 200
+        assert cron_st_resp['message'] == 'success'
+
+    def test_check_generated_cron_scheduled_events(self,hge_ctx):
+        future_schedule_timestamps = []
+        iter = croniter(self.cron_schedule,self.init_time)
+        for i in range(100):
+            future_schedule_timestamps.append(iter.next(datetime))
+        sql = '''
+    select scheduled_time from hdb_catalog.hdb_scheduled_events where
+        name = '{}' order by scheduled_time asc;
+    '''
+        q = {
+            "type":"run_sql",
+            "args":{
+                "sql":sql.format(self.cron_trigger_name)
+            }
+        }
+        st,resp = hge_ctx.v1q(q)
+        assert st == 200
+        ts_resp = resp['result'][1:]
+        assert len(ts_resp) == 100 # 100 events are generated in a cron ST
+        scheduled_events_ts = []
+        for ts in ts_resp:
+            datetime_ts = datetime.strptime(ts[0],"%Y-%m-%d %H:%M:%S")
+            scheduled_events_ts.append(datetime_ts)
+        assert future_schedule_timestamps == scheduled_events_ts
+
+    def test_delete_cron_scheduled_trigger(self,hge_ctx):
+        q = {
+            "type":"delete_scheduled_trigger",
+            "args":{
+                "name":self.cron_trigger_name
+            }
+        }
+        st,resp = hge_ctx.v1q(q)
+        assert st == 200,resp
+
+class ScheduledEventNotFound(Exception):
+    pass
+
+@pytest.mark.usefixtures("scheduled_triggers_evts_webhook")
+class TestScheduledTriggerAdhoc(object):
+
+    adhoc_trigger_name = "adhoc_trigger"
+    webhook_path = "/hello"
+    # maximum wait time is retries * interval_in_secs = 60 secs
+    webhook_payload = {"foo":"baz"}
+    url = "/v1/query"
+
+    @classmethod
+    def dir(cls):
+        return 'queries/scheduled_triggers'
+
+    def poll_until_scheduled_event_found(self,scheduled_triggers_evts_webhook,retries=12,interval_in_secs=5.0):
+        while (retries > 0):
+            try:
+                ev_full = scheduled_triggers_evts_webhook.get_event(3)
+                return ev_full
+            except Empty:
+                retries = retries - 1
+                time.sleep(interval_in_secs)
+        raise ScheduledEventNotFound # retries exhausted
+
+    def test_create_adhoc_scheduled_trigger(self,hge_ctx,scheduled_triggers_evts_webhook):
+        q = {
+            "type":"run_sql",
+            "args":{
+                "sql":"set time zone 'UTC'"
+            }
+        }
+        st,resp = hge_ctx.v1q(q)
+        current_time = datetime.utcnow()
+        current_time_str =  stringify_datetime(current_time)
+        adhoc_st_api_query = {
+            "type":"create_scheduled_trigger",
+            "args":{
+                "name":self.adhoc_trigger_name,
+                "webhook":"http://127.0.0.1:5594" + self.webhook_path,
+                "schedule":{
+                    "type":"adhoc",
+                    "value":current_time_str
+                },
+                "payload":self.webhook_payload,
+                "headers":[
+                    {
+                        "name":"header-1",
+                        "value":"header-1-value"
+                    }
+                ]
+            }
+        }
+        headers = {}
+        if hge_ctx.hge_key is not None:
+            headers['X-Hasura-Admin-Secret'] = hge_ctx.hge_key
+        adhoc_st_code,adhoc_st_resp,_ = hge_ctx.anyq(self.url,adhoc_st_api_query,headers)
+        assert adhoc_st_resp['message'] == 'success'
+        assert adhoc_st_code == 200
+
+    def test_check_adhoc_generated_event(self,hge_ctx,scheduled_triggers_evts_webhook):
+        adhoc_event_st,adhoc_event_resp = get_events_of_scheduled_trigger(hge_ctx,self.adhoc_trigger_name)
+        assert int(adhoc_event_resp['result'][1][0]) == 1 # An adhoc ST should create exactly one schedule event
+
+    def test_check_adhoc_webhook_event(self,hge_ctx,scheduled_triggers_evts_webhook):
+        ev_full = self.poll_until_scheduled_event_found(scheduled_triggers_evts_webhook)
+        validate_event_webhook(ev_full['path'],'/hello')
+        validate_event_headers(ev_full['headers'],{"header-1":"header-1-value"})
+        assert ev_full['body'] == self.webhook_payload
+        time.sleep(1.0) # sleep for 1s more to check if any other events were also fired
+
+        assert scheduled_triggers_evts_webhook.is_queue_empty()
+
+    def test_delete_adhoc_scheduled_trigger(self,hge_ctx,scheduled_triggers_evts_webhook):
+        q = {
+            "type":"delete_scheduled_trigger",
+            "args":{
+                "name":self.adhoc_trigger_name
+            }
+        }
+        st,resp = hge_ctx.v1q(q)
+        assert st == 200,resp


### PR DESCRIPTION
- what:
  - Make a new scheduled events webhook server on port 5594
  - Setting the session timezone of the db to UTC so that
    "SELECT NOW()" returns UTC time.
  - Cron's schedule is set from 30 mins from the time the tests run, so it
    will not be run(to avoid race condition between the cron ST and the adhoc
    ST)
  - The tests will run for a maximum of a minute(until the event is fired)

<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
<!-- The title might not be enough to convey how this change affects the user. -->
<!-- Describe the changes from a user's perspective -->

### Affected components
<!-- Remove non-affected components from the list -->

- [ ] Server
- [ ] Console
- [ ] CLI
- [ ] Docs
- [ ] Community Content
- [ ] Build System
- [ ] Tests
- [ ] Other (list it)

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [ ] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://docs.hasura.io/1.0/graphql/manual/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ ] No
- [ ] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [ ] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [ ] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [ ] Not required


#### GraphQL
- [ ] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [ ] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
